### PR TITLE
fix for unwanted quotation marks and $

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-scripts": "1.1.4",
+    "uglify-js": "^3.4.6",
     "whatwg-fetch": "^2.0.4"
   },
   "scripts": {

--- a/src/components/Business/Business.js
+++ b/src/components/Business/Business.js
@@ -13,12 +13,12 @@ class Business extends Component {
     <div className="Business-address">
       <p>{this.props.business.address}</p>
       <p>{this.props.business.city}</p>
-      <p>`${this.props.business.state} ${this.props.business.zipCode}`</p>
+      <p>{this.props.business.state} {this.props.business.zipCode}</p>
     </div>
     <div className="Business-reviews">
       <h3>{this.props.business.category}</h3>
-      <h3 className="rating">`${this.props.business.rating} stars`</h3>
-      <p>`{this.props.business.reviewCount} reviews`</p>
+      <h3 className="rating">{`${this.props.business.rating} stars`}</h3>
+      <p>{`${this.props.business.reviewCount} reviews`}</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
When doing searches, the `$` new string substitution wasn't working as expected because I needed an extra pair of {} to tell it to interpret those symbols accordingly.  Otherwise html was just coding it as is using the symbols `` and $.